### PR TITLE
Исправление баги с разрушением оценки

### DIFF
--- a/ShikiRating.user.js
+++ b/ShikiRating.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Shiki Rating
 // @namespace    http://shikimori.org/
-// @version      2.5
+// @version      2.6
 // @description  Rating from shiki users
 // @author       ImoutoChan
 // @match        http://shikimori.org/*
@@ -101,7 +101,7 @@ function appendShikiRating() {
     var totalCount = 0;
     for (var i = 0; i < scoreData.length; i++) {
         sumScore += scoreData[i].value * scoreData[i].key;
-        totalCount += scoreData[i].value;
+        totalCount += scoreData[i].value * 1;
     }
     var shikiScore = sumScore / totalCount;
     var shikiScoreDigit = Math.round(shikiScore);


### PR DESCRIPTION
http://screenshot.ru/023977610b8516a6bfcae5b22f836c03.png Шики допускает в рейтинге текстовые значения оценок типа "9,0" вместо числа 9. Ошибка суммирования текста с числом, текст приписывается справа, последующее деление даёт почти десятикратную ошибку и имеет характерную десятичную точку

Всегда приводи данные к нужному типу! Складываешь - значит, приводи входящее к числу!