### PR TITLE
Update ShikiRating.user.js

### DIFF
--- a/ShikiRating.user.js
+++ b/ShikiRating.user.js
@@ -100,8 +100,8 @@ function appendShikiRating() {
     var sumScore = 0;
     var totalCount = 0;
     for (var i = 0; i < scoreData.length; i++) {
-        sumScore += scoreData[i].value * scoreData[i].key;
-        totalCount += scoreData[i].value * 1;
+        sumScore += scoreData[i][1] * scoreData[i][0];
+        totalCount += scoreData[i][1] * 1;
     }
     var shikiScore = sumScore / totalCount;
     var shikiScoreDigit = Math.round(shikiScore);


### PR DESCRIPTION
Shikimori теперь предоставляет данные не как обьекты, а к ак два элемента масива, из-за этого поля `key` и `value` теперь `undefined`. Из-за этого рейтинг показывался как `NaN`

Это не точно, т.к. сюда я раньше не лез (в данные с помощью которых вообще это всё считаеться, и всё это мои предположения), но как факт теперь плагин работает исправно.