### PR TITLE
Fix scoreData null error

### DIFF
--- a/ShikiRating.user.js
+++ b/ShikiRating.user.js
@@ -94,7 +94,7 @@ function appendShikiRating() {
     log(scoreDataJson);
 
     // set no data lable
-    if (scoreData.length === 0) {
+    if (scoreData === null || scoreData.length === 0) {
         setNoData(newShikiRate);
         return;
     }

--- a/ShikiRating.user.js
+++ b/ShikiRating.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Shiki Rating
 // @namespace    http://shikimori.org/
-// @version      2.8.2
+// @version      2.8.3
 // @description  Rating from shiki users
 // @author       ImoutoChan
 // @match        http://shikimori.org/*


### PR DESCRIPTION
## Проблема
Когда Shikimori показывает *"Оценки людей - Нет данных"*. Объект `scoreData` возвращается типа `null` и из за этого скрипт немного ломается. (Хоть и не критично)

## Решение
Просто добавил проверку `scoreData` на значение `null` и вызываю в таком случае `setNoData()` и делаю `return` в уже готовой реализации.

## До:
![Before](https://github.com/ImoutoChan/shiki-rating-userscript/assets/58055542/3d864357-5589-4b83-bec8-515342478d0c)

## После:
![After](https://github.com/ImoutoChan/shiki-rating-userscript/assets/58055542/12bba82a-582b-4524-a2dc-d252a8e5982c)