### PR TITLE
Новый match pattern для нового домена https://shiki.one/*

### DIFF
--- a/ShikiRating.user.js
+++ b/ShikiRating.user.js
@@ -10,6 +10,7 @@
 // @match        https://shikimori.one/*
 // @match        http://shikimori.me/*
 // @match        https://shikimori.me/*
+// @match        https://shiki.one/*
 // @downloadURL  https://github.com/ImoutoChan/shiki-rating-userscript/raw/master/ShikiRating.user.js
 // @updateURL    https://github.com/ImoutoChan/shiki-rating-userscript/raw/master/ShikiRating.user.js
 // @license      MIT


### PR DESCRIPTION
Новый match pattern для домена `https://shiki.one/*`, который пришёл на замену оригинальному `https://shikimori.one/*` после недавней блокировки от РКН.

В данный момент все запросы на `https://shikimori.one/*` редиректятся админами сайта на новый `https://shiki.one/*`, но Ваш Tampermonkey плагин это не учитывает.

Мой Pull request как раз и решает эту проблему.

[Ссылка на новость на Шикимори](https://shiki.one/forum/news/619312-rkn-zablokiroval-shikimori).